### PR TITLE
fix(ci): correct typo in sam deploy command options

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,4 +90,4 @@ jobs:
         run: |
           sam deploy \
           --no-confirm-changeset \
-          -no-fail-on-empty-changeset
+          --no-fail-on-empty-changeset


### PR DESCRIPTION
Changes '-no-fail-on-empty-changeset' to '--no-fail-on-empty-changeset' in the CI deployment step to resolve 'No such option: -n' error.