### PR TITLE
fix(ci): explicitly specify config file for sam deploy

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,5 +89,7 @@ jobs:
       - name: Deploy SAM Application
         run: |
           sam deploy \
+          --config-file samcomfig.toml \
+          --config-env default \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset


### PR DESCRIPTION
Updates sam deploy command in CI to use --config-file samconfig.toml --config-env default to ensure stack name and other parameters are loaded correctly.