### PR TITLE
fix(ci): correct typo in samconfig.toml filename for sam deploy

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Deploy SAM Application
         run: |
           sam deploy \
-          --config-file samcomfig.toml \
+          --config-file samconfig.toml \
           --config-env default \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset


### PR DESCRIPTION
Changes --config-file 'samcomfig.toml' to 'samconfig.toml' in the CI deployment step.