### PR TITLE
fix(ci): explicitly provide stack-name to sam deploy

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Deploy SAM Application
         run: |
           sam deploy \
+          --stack-name MyFastAPIApp \
           --config-file samconfig.toml \
           --config-env default \
           --no-confirm-changeset \


### PR DESCRIPTION
Updates the sam deploy command in CI to include the --stack-name parameter directly, in addition to using samconfig.toml, to resolve missing option error.