### PR TITLE
fix(ci): explicitly specify template file for sam deploy

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           sam deploy \
           --stack-name MyFastAPIApp \
+          --template-file template.yaml \
           --config-file samconfig.toml \
           --config-env default \
           --no-confirm-changeset \


### PR DESCRIPTION
Updates sam deploy command in CI to use --template-file template.yaml to ensure correct template path resolution.