### PR TITLE
fix(ci): point sam deploy to the template generated by sam build

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           sam deploy \
           --stack-name MyFastAPIApp \
-          --template-file template.yaml \
+          --template-file .aws-sam/build/template.yaml \
           --config-file samconfig.toml \
           --config-env default \
           --no-confirm-changeset \


### PR DESCRIPTION
Updates the sam deploy command in CI to explicitly use the template file from the .aws-sam/build directory, ensuring the correct, processed template is deployed.