### PR TITLE
chore(ci): temporarily disable deploy job in workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,4 @@
-name: Run Python Tests, Linter, and Deploy
+name: Run Python Tests, Linter #, and Deploy
 
 on:
   push:
@@ -51,47 +51,47 @@ jobs:
         run: |
           pytest --cov=backend --cov-report=term-missing
 
-  deploy:
-    name: Deploy to AWS
-    runs-on: ubuntu-latest
-    needs: test-and-lint
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' # Only run on pushes to main
+#   deploy:
+#     name: Deploy to AWS
+#     runs-on: ubuntu-latest
+#     needs: test-and-lint
+#     if: github.ref == 'refs/heads/main' && github.event_name == 'push' # Only run on pushes to main
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+#     steps:
+#       - name: Check out code
+#         uses: actions/checkout@v4
 
-      # We might not need to setup Python specifically for SAM CLI if it's self-contained
-      # or if the runner has a compatible version. But it's safer to include.
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+#       # We might not need to setup Python specifically for SAM CLI if it's self-contained
+#       # or if the runner has a compatible version. But it's safer to include.
+#       - name: Set up Python
+#         uses: actions/setup-python@v5
+#         with:
+#           python-version: "3.12"
 
-      # SAM CLI is often pre-installed on GitHub runners.
-      # If not, we would add a step here to install it, e.g.:
-      # - name: Install AWS SAM CLI
-      #   run: pip install aws-sam-cli
+#       # SAM CLI is often pre-installed on GitHub runners.
+#       # If not, we would add a step here to install it, e.g.:
+#       # - name: Install AWS SAM CLI
+#       #   run: pip install aws-sam-cli
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-3
+#       - name: Configure AWS Credentials
+#         uses: aws-actions/configure-aws-credentials@v4
+#         with:
+#           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#           aws-region: eu-west-3
 
-      - name: Build SAM Application
-        working-directory: ./backend
-        run: |
-          sam build \
-          --use-container
+#       - name: Build SAM Application
+#         working-directory: ./backend
+#         run: |
+#           sam build \
+#           --use-container
 
-      - name: Deploy SAM Application
-        run: |
-          sam deploy \
-          --stack-name MyFastAPIApp \
-          --template-file .aws-sam/build/template.yaml \
-          --config-file samconfig.toml \
-          --config-env default \
-          --no-confirm-changeset \
-          --no-fail-on-empty-changeset
+#       - name: Deploy SAM Application
+#         run: |
+#           sam deploy \
+#           --stack-name MyFastAPIApp \
+#           --template-file .aws-sam/build/template.yaml \
+#           --config-file samconfig.toml \
+#           --config-env default \
+#           --no-confirm-changeset \
+#           --no-fail-on-empty-changeset


### PR DESCRIPTION
Comments out the automated deployment job to prevent CI failures on the main branch while troubleshooting. The test and lint job remains active. Automated deployment will be revisited.